### PR TITLE
convoluted error handling

### DIFF
--- a/node.go
+++ b/node.go
@@ -279,11 +279,22 @@ func (a *Node) prepare(b ballot, key []byte) (acceptorState, error) {
 	defer a.Unlock()
 
 	state, err := a.acceptorStore.Get(key)
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors. this because most implementations of raft/StableStore return an error
+		// if value is a nil byte:: https://github.com/hashicorp/raft-boltdb/blob/6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3/bolt_store.go#L243-L245
+		// TODO: do better
+		state, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{}, errors.Wrap(err, fmt.Sprintf("unable to get state for key:%v from acceptor:%v", key, a.ID))
 	}
 
 	acceptedBallotBytes, err := a.acceptorStore.Get(acceptedBallotKey(key))
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors
+		// TODO: do better
+		acceptedBallotBytes, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{state: state}, errors.Wrap(err, fmt.Sprintf("unable to get acceptedBallot of acceptor:%v", a.ID))
 	}
@@ -303,6 +314,11 @@ func (a *Node) prepare(b ballot, key []byte) (acceptorState, error) {
 	}
 
 	promisedBallotBytes, err := a.acceptorStore.Get(promisedBallotKey(key))
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors
+		// TODO: do better
+		promisedBallotBytes, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{state: state, acceptedBallot: acceptedBallot}, errors.Wrap(err, fmt.Sprintf("unable to get promisedBallot of acceptor:%v", a.ID))
 	}
@@ -352,11 +368,21 @@ func (a *Node) accept(b ballot, key []byte, state []byte) (acceptorState, error)
 	defer a.Unlock()
 
 	state, err := a.acceptorStore.Get(key)
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors
+		// TODO: do better
+		state, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{}, errors.Wrap(err, fmt.Sprintf("unable to get state for key:%v from acceptor:%v", key, a.ID))
 	}
 
 	acceptedBallotBytes, err := a.acceptorStore.Get(acceptedBallotKey(key))
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors
+		// TODO: do better
+		acceptedBallotBytes, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{state: state}, errors.Wrap(err, fmt.Sprintf("unable to get acceptedBallot of acceptor:%v", a.ID))
 	}
@@ -377,6 +403,11 @@ func (a *Node) accept(b ballot, key []byte, state []byte) (acceptorState, error)
 	}
 
 	promisedBallotBytes, err := a.acceptorStore.Get(promisedBallotKey(key))
+	if err != nil && err.Error() == "not found" {
+		// unfortunate way of handling errors
+		// TODO: do better
+		promisedBallotBytes, err = nil, nil
+	}
 	if err != nil {
 		return acceptorState{state: state, acceptedBallot: acceptedBallot}, errors.Wrap(err, fmt.Sprintf("unable to get promisedBallot of acceptor:%v", a.ID))
 	}


### PR DESCRIPTION
- Most implementations[1][2] of raft StableStore interface; when you do a get for a key and the value returned happens to be a nil []byte, then they return an error.
- Since we are using StableStore interface to persist (ballots and state), we need to check if the state exists(ie do a get). But instead of throwing an error if state is nil []byte, we need to 'catch' it and set it to nil. 
- it looks hideous and should be replaced with something better.


ref:
1. https://github.com/hashicorp/raft-boltdb/blob/6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3/bolt_store.go#L243-L245
2. https://github.com/hashicorp/raft-mdb/blob/55f29473b9e604b3678b93a8433a6cf089e70f76/mdb_store.go#L328-L329